### PR TITLE
Update 98_MediaList.pm

### DIFF
--- a/FHEM/98_MediaList.pm
+++ b/FHEM/98_MediaList.pm
@@ -43,7 +43,7 @@ use IO::File;
 use Fcntl;
 use File::Basename;
 use File::Copy;
-use Math::Round qw/round/;
+use Math::Round ();
 require 'Blocking.pm';
 require 'HttpUtils.pm';
 use vars qw($readingFnAttributes);
@@ -582,7 +582,7 @@ sub MediaList_GetMP3Tags($$) {
     utf8::encode($album);
     utf8::encode($comment);
 
-    $res = {"Artist" => $artist, "Title" => $title, "Album" => $album, "Time" => round($mp3info->{SECS}), "File" => $file, "Cover" => ""};
+    $res = {"Artist" => $artist, "Title" => $title, "Album" => $album, "Time" => math::round($mp3info->{SECS}), "File" => $file, "Cover" => ""};
     Log3  $hash, 5, "GetMP3Tags: ".Dumper($res);
 
     return $res;


### PR DESCRIPTION
The usage of the math lib imports a sub round in the main namespcae.
There is already a sub callled round in this namespace provided.

The previous used import does overwrite the existing functions, leading to errors in FHEM if the round function is used.

This patch prevents the overwrite of fhem round sub from 99_Utils.

https://forum.fhem.de/index.php?topic=100268.new#new

Description of this problem in other Modules:
https://github.com/RFD-FHEM/RFFHEM/issues/580